### PR TITLE
Wrapping of TextInput works in iOS fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,9 @@ export default class ModalSelector extends BaseComponent {
             <View style={this.props.style}>
                 {dp}
                 <TouchableOpacity onPress={this.open}>
-                    {this.renderChildren()}
+                    <View pointerEvents="none">
+                        {this.renderChildren()}
+                    </View>
                 </TouchableOpacity>
             </View>
         );


### PR DESCRIPTION
 I have set the prop to `"none"`, it could also be set to `{this.state.modalVisible ? 'auto' : 'none'}`, that would make the children receive any touch-events while the modal is visible, but since the modal is covering the screen I don't think that would make any sense, and just add more logic with no use.