### PR TITLE
Prop to change supported orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ class SampleApp extends Component {
                 <ModalSelector
                     data={data}
                     initValue="Select something yummy!"
+                    supportedOrientations={['landscape']}
                     onChange={(option)=>{ this.setState({textInputValue:option.label})}}>
 
                     <TextInput
@@ -100,4 +101,5 @@ NOTE: Due to breaking changes in React Native, RN < 0.39.0 should pass `flex:1` 
 *   `cancelStyle` (object, optional) style definitions for the cancel element
 *   `cancelTextStyle` (object, optional) style definitions for the cancel text element
 *   `disabled` (bool, optional, default false) disable opening of the modal
+*   `supportedOrientations` (`['portrait', 'landscape']`, optional, default both), orientations the modal support
 *   `keyboardShouldPersistTaps` (string/bool, optional, default 'always') passed to underlying ScrollView

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const propTypes = {
     overlayStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
     cancelText: PropTypes.string,
     disabled: PropTypes.bool,
-    supportedOrientations: PropTypes.arrayOf(PropTypes.oneOfType(['portrait', 'landscape'])),
+    supportedOrientations: PropTypes.arrayOf(PropTypes.oneOfType(['portrait', 'landscape', 'portrait-upside-down', 'landscape-left', 'landscape-right'])),
     keyboardShouldPersistTaps: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
 };
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const propTypes = {
     overlayStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
     cancelText: PropTypes.string,
     disabled: PropTypes.bool,
+    supportedOrientations: PropTypes.arrayOf(PropTypes.oneOfType(['portrait', 'landscape'])),
     keyboardShouldPersistTaps: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
 };
 
@@ -54,6 +55,7 @@ const defaultProps = {
     overlayStyle: {},
     cancelText: 'cancel',
     disabled: false,
+    supportedOrientations: ['portrait', 'landscape'],
     keyboardShouldPersistTaps: 'always'
 };
 
@@ -171,7 +173,7 @@ export default class ModalSelector extends BaseComponent {
           <Modal
               transparent={true}
               ref="modal"
-              supportedOrientations={['landscape', 'portrait']}
+              supportedOrientations={this.props.supportedOrientations}
               visible={this.state.modalVisible}
               onRequestClose={this.close}
               animationType={this.state.animationType}


### PR DESCRIPTION
I added the prop to the example to clearify it's use.

I mimiced how `supportedOrientations` works for RN Modal in how the options are organised (as an array of strings).