### PR TITLE
reverted style changes introduced in orientation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Prop                | Type     | Optional | Default      | Description
 `style`             | object   | Yes      |              | style definitions for the root element
 `selectStyle`       | object   | Yes      | {}           | style definitions for the select element (available in default mode only!). NOTE: Due to breaking changes in React Native, RN < 0.39.0 should pass `flex:1` explicitly to `selectStyle` as a prop.
 `selectTextStyle`   | object   | Yes      | {}           | style definitions for the select element (available in default mode only!)
-`overlayStyle`      | object   | Yes      | {}           | style definitions for the overly/background element
+`overlayStyle`      | object   | Yes      | { flex: 1, padding: '5%', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.7)' } | style definitions for the overlay background element. RN <= 0.41 should override this with pixel value for padding.
 `sectionStyle`      | object   | Yes      | {}           | style definitions for the section element
 `sectionTextStyle`  | object   | Yes      | {}           | style definitions for the select text element
 `optionStyle`       | object   | Yes      | {}           | style definitions for the option element

--- a/style.js
+++ b/style.js
@@ -25,7 +25,7 @@ export default StyleSheet.create({
     },
 
     cancelContainer: {
-        flex:      1,
+        flexGrow:  1,
         maxHeight: 30,
         alignSelf: 'stretch',
     },

--- a/style.js
+++ b/style.js
@@ -11,14 +11,14 @@ export default StyleSheet.create({
 
     overlayStyle: {
         flex:            1,
-        padding:         30,
+        padding:         '10%',
         justifyContent:  'center',
         backgroundColor: 'rgba(0,0,0,0.7)',
     },
 
     optionContainer: {
         borderRadius:    BORDER_RADIUS,
-        flex:            1,
+        flexShrink:      1,
         marginBottom:    8,
         padding:         PADDING,
         backgroundColor: 'rgba(255,255,255,0.8)',

--- a/style.js
+++ b/style.js
@@ -11,7 +11,7 @@ export default StyleSheet.create({
 
     overlayStyle: {
         flex:            1,
-        padding:         '10%',
+        padding:         '5%',
         justifyContent:  'center',
         backgroundColor: 'rgba(0,0,0,0.7)',
     },


### PR DESCRIPTION
The fixes to support both orientations made the modal look quite different. These changes keep the modal styled the same as before the orientation changes but also allows the modal to size correctly in both orientations.