### PR TITLE
Optionally close the modal by pressing the overlay

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import {
     Text,
     ScrollView,
     TouchableOpacity,
+    TouchableWithoutFeedback,
     ViewPropTypes as RNViewPropTypes,
 } from 'react-native';
 
@@ -39,6 +40,7 @@ const propTypes = {
     disabled:                  PropTypes.bool,
     supportedOrientations:     PropTypes.arrayOf(PropTypes.oneOf(['portrait', 'landscape', 'portrait-upside-down', 'landscape-left', 'landscape-right'])),
     keyboardShouldPersistTaps: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    pressClosesOverlay:        PropTypes.bool,
 };
 
 const defaultProps = {
@@ -61,6 +63,7 @@ const defaultProps = {
     disabled:                  false,
     supportedOrientations:     ['portrait', 'landscape'],
     keyboardShouldPersistTaps: 'always',
+    pressClosesOverlay:        false,
 };
 
 export default class ModalSelector extends BaseComponent {
@@ -138,24 +141,27 @@ export default class ModalSelector extends BaseComponent {
 
         });
 
-        return (
-            <View style={[styles.overlayStyle, this.props.overlayStyle]} key={'modalSelector'+(componentIndex++)}>
-                <View style={[styles.optionContainer, this.props.optionContainerStyle]}>
-                    <ScrollView keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}>
-                        <View style={{paddingHorizontal: 10}}>
-                            {options}
-                        </View>
-                    </ScrollView>
-                </View>
-                <View style={styles.cancelContainer}>
-                    <TouchableOpacity onPress={this.close}>
-                        <View style={[styles.cancelStyle, this.props.cancelStyle]}>
-                            <Text style={[styles.cancelTextStyle,this.props.cancelTextStyle]}>{this.props.cancelText}</Text>
-                        </View>
-                    </TouchableOpacity>
-                </View>
+        const closeOverlay = this.props.pressClosesOverlay;
 
-            </View>);
+        return (
+            <TouchableWithoutFeedback key={'modalSelector' + (componentIndex++)} onPress={() => {closeOverlay && this.close()}}>
+                <View style={[styles.overlayStyle, this.props.overlayStyle]}>
+                    <View style={[styles.optionContainer, this.props.optionContainerStyle]}>
+                        <ScrollView keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}>
+                            <View style={{paddingHorizontal: 10}}>
+                                {options}
+                            </View>
+                        </ScrollView>
+                    </View>
+                    <View style={styles.cancelContainer}>
+                        <TouchableOpacity onPress={this.close}>
+                            <View style={[styles.cancelStyle, this.props.cancelStyle]}>
+                                <Text style={[styles.cancelTextStyle,this.props.cancelTextStyle]}>{this.props.cancelText}</Text>
+                            </View>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </TouchableWithoutFeedback>);
     }
 
     renderChildren() {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const propTypes = {
     disabled:                  PropTypes.bool,
     supportedOrientations:     PropTypes.arrayOf(PropTypes.oneOf(['portrait', 'landscape', 'portrait-upside-down', 'landscape-left', 'landscape-right'])),
     keyboardShouldPersistTaps: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    pressClosesOverlay:        PropTypes.bool,
+    closeModalOnOverlayPress:  PropTypes.bool,
 };
 
 const defaultProps = {
@@ -63,7 +63,7 @@ const defaultProps = {
     disabled:                  false,
     supportedOrientations:     ['portrait', 'landscape'],
     keyboardShouldPersistTaps: 'always',
-    pressClosesOverlay:        false,
+    closeModalOnOverlayPress:  false,
 };
 
 export default class ModalSelector extends BaseComponent {
@@ -141,7 +141,7 @@ export default class ModalSelector extends BaseComponent {
 
         });
 
-        const closeOverlay = this.props.pressClosesOverlay;
+        const closeOverlay = this.props.closeModalOnOverlayPress;
 
         return (
             <TouchableWithoutFeedback key={'modalSelector' + (componentIndex++)} onPress={() => {closeOverlay && this.close()}}>

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const propTypes = {
     disabled:                  PropTypes.bool,
     supportedOrientations:     PropTypes.arrayOf(PropTypes.oneOf(['portrait', 'landscape', 'portrait-upside-down', 'landscape-left', 'landscape-right'])),
     keyboardShouldPersistTaps: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    closeModalOnOverlayPress:  PropTypes.bool,
+    backdropPressToClose:      PropTypes.bool,
 };
 
 const defaultProps = {
@@ -63,7 +63,7 @@ const defaultProps = {
     disabled:                  false,
     supportedOrientations:     ['portrait', 'landscape'],
     keyboardShouldPersistTaps: 'always',
-    closeModalOnOverlayPress:  false,
+    backdropPressToClose:      false,
 };
 
 export default class ModalSelector extends BaseComponent {
@@ -141,7 +141,7 @@ export default class ModalSelector extends BaseComponent {
 
         });
 
-        const closeOverlay = this.props.closeModalOnOverlayPress;
+        const closeOverlay = this.props.backdropPressToClose;
 
         return (
             <TouchableWithoutFeedback key={'modalSelector' + (componentIndex++)} onPress={() => {closeOverlay && this.close()}}>


### PR DESCRIPTION
In response to Close Modal on overlay click https://github.com/peacechen/react-native-modal-selector/issues/28 I have made it possible to pass a prop to the component ('closeModalOnOverlayPress', boolean, default value is false) which when true will close the modal but calling the close() method, just as pressing the 'cancel' button in the modal does.