### PR TITLE
Fix onChange when modal closes

### DIFF
--- a/SampleApp/.flowconfig
+++ b/SampleApp/.flowconfig
@@ -37,8 +37,8 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(5[0-3]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(5[0-3]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(5[0-6]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(5[0-6]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 

--- a/SampleApp/package.json
+++ b/SampleApp/package.json
@@ -10,8 +10,8 @@
     "nodemon": "nodemon nodemon.json"
   },
   "dependencies": {
-    "react": "16.0.0-beta.5",
-    "react-native": "0.49.3",
+    "react": "16.0.0",
+    "react-native": "0.50.1",
     "react-native-modal-selector": "file:../"
   },
   "devDependencies": {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ import BaseComponent from './BaseComponent';
 const ViewPropTypes = RNViewPropTypes || View.propTypes;
 
 let componentIndex = 0;
+let rnVersion = Number.parseFloat(require('react-native/package.json').version);
 
 const propTypes = {
     data:                      PropTypes.array,
@@ -83,6 +84,7 @@ export default class ModalSelector extends BaseComponent {
             modalVisible:  false,
             transparent:   false,
             selected:      'please select',
+            changedItem:   undefined,
         };
     }
 
@@ -98,9 +100,9 @@ export default class ModalSelector extends BaseComponent {
     }
 
     onChange(item) {
-        this.props.onChange(item);
-        this.setState({selected: item.label});
-        this.close();
+        rnVersion < 0.50 && this.props.onChange(item);
+        this.setState({selected: item.label, changedItem: item });
+        this.close()
     }
 
     close() {
@@ -112,6 +114,7 @@ export default class ModalSelector extends BaseComponent {
     open() {
         this.setState({
             modalVisible: true,
+            changedItem: undefined,
         });
     }
 
@@ -186,6 +189,7 @@ export default class ModalSelector extends BaseComponent {
                 visible={this.state.modalVisible}
                 onRequestClose={this.close}
                 animationType={this.props.animationType}
+                onDismiss={() => this.state.changedItem && this.props.onChange(this.state.changedItem)}
             >
                 {this.renderOptionList()}
             </Modal>


### PR DESCRIPTION
From RN 0.50 it is a prop called [onDismiss](https://github.com/facebook/react-native/commit/a389ffbd84224b583e71cf7c1468409cbc91ec8e) available with Modal-component. This fixes issue #6 