### PR TITLE
Use arrow instead of bind

### DIFF
--- a/BaseComponent.js
+++ b/BaseComponent.js
@@ -1,9 +1,0 @@
-'use strict';
-
-import React from 'react';
-
-export default class BaseComponent extends React.Component {
-    _bind(...methods) {
-        methods.forEach(method => this[method] = this[method].bind(this));
-    }
-}

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ import {
 } from 'react-native';
 
 import styles from './style';
-import BaseComponent from './BaseComponent';
 
 const ViewPropTypes = RNViewPropTypes || View.propTypes;
 
@@ -39,7 +38,7 @@ const propTypes = {
     overlayStyle:              ViewPropTypes.style,
     cancelText:                PropTypes.string,
     disabled:                  PropTypes.bool,
-    supportedOrientations:     PropTypes.arrayOf(PropTypes.oneOf(['portrait', 'landscape', 'portrait-upside-down', 'landscape-left', 'landscape-right'])),
+    supportedOrientations:     Modal.propTypes.supportedOrientations,
     keyboardShouldPersistTaps: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     backdropPressToClose:      PropTypes.bool,
 };

--- a/index.js
+++ b/index.js
@@ -67,18 +67,11 @@ const defaultProps = {
     backdropPressToClose:      false,
 };
 
-export default class ModalSelector extends BaseComponent {
+export default class ModalSelector extends React.Component {
 
     constructor() {
 
         super();
-
-        this._bind(
-            'onChange',
-            'open',
-            'close',
-            'renderChildren'
-        );
 
         this.state = {
             modalVisible:  false,
@@ -99,7 +92,7 @@ export default class ModalSelector extends BaseComponent {
         }
     }
 
-    onChange(item) {
+    onChange = (item) => {
         if (Platform.OS === 'android' || !Modal.propTypes.onDismiss) {
           // RN >= 0.50 on iOS comes with the onDismiss prop for Modal which solves RN issue #10471
           this.props.onChange(item)
@@ -108,20 +101,20 @@ export default class ModalSelector extends BaseComponent {
         this.close();
     }
 
-    close() {
+    close = () => {
         this.setState({
             modalVisible: false,
         });
     }
 
-    open() {
+    open = () => {
         this.setState({
             modalVisible: true,
             changedItem: undefined,
         });
     }
 
-    renderSection(section) {
+    renderSection = (section) => {
         return (
             <View key={section.key} style={[styles.sectionStyle,this.props.sectionStyle]}>
                 <Text style={[styles.sectionTextStyle,this.props.sectionTextStyle]}>{section.label}</Text>
@@ -129,7 +122,7 @@ export default class ModalSelector extends BaseComponent {
         );
     }
 
-    renderOption(option, isLastItem) {
+    renderOption = (option, isLastItem) => {
         return (
             <TouchableOpacity key={option.key} onPress={() => this.onChange(option)}>
                 <View style={[styles.optionStyle, this.props.optionStyle, isLastItem &&
@@ -139,7 +132,7 @@ export default class ModalSelector extends BaseComponent {
             </TouchableOpacity>);
     }
 
-    renderOptionList() {
+    renderOptionList = () => {
         
         let options = this.props.data.map((item, index) => {
             if (item.section) {
@@ -171,7 +164,7 @@ export default class ModalSelector extends BaseComponent {
             </TouchableWithoutFeedback>);
     }
 
-    renderChildren() {
+    renderChildren = () => {
 
         if(this.props.children) {
             return this.props.children;

--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ export default class ModalSelector extends React.Component {
 
         this.state = {
             modalVisible:  false,
-            transparent:   false,
             selected:      'please select',
             changedItem:   undefined,
         };

--- a/index.js
+++ b/index.js
@@ -68,20 +68,15 @@ const defaultProps = {
 
 export default class ModalSelector extends React.Component {
 
-    constructor() {
-
-        super();
+    constructor(props) {
+        super(props);
 
         this.state = {
             modalVisible:  false,
-            selected:      'please select',
+            selected:      props.initValue,
+            cancelText:    props.cancelText,
             changedItem:   undefined,
         };
-    }
-
-    componentDidMount() {
-        this.setState({selected: this.props.initValue});
-        this.setState({cancelText: this.props.cancelText});
     }
 
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
* Using arrow functions instead of binding class methods
* Using original prop-types for supported orientations of Modal
* Initialize state in `constructor` and not in `componentDidMount` (which is a "no-op")