### PR TITLE
Add modal opening/closing event

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Prop                | Type     | Optional | Default      | Description
 ------------------- | -------- | -------- | ------------ | -----------
 `data`              | array    | No       | []           | array of objects with a unique key and label to select in the modal.
 `onChange`          | function | Yes      | () => {}     | callback function, when the users has selected an option
+`onModalOpen`       | function | Yes      | () => {}     | callback function, when modal is opening
+`onModalClose`      | function | Yes      | () => {}     | callback function, when modal is closing
 `keyExtractor       | function | Yes      | (data) => data.key   | extract the key from the data item
 `labelExtractor     | function | Yes      | (data) => data.label | extract the label from the data item
 `initValue`         | string   | Yes      | `Select me!` | text that is initially shown on the button

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ let componentIndex = 0;
 const propTypes = {
     data:                           PropTypes.array,
     onChange:                       PropTypes.func,
+    onModalOpen:                    PropTypes.func,
+    onModalClose:                   PropTypes.func,
     keyExtractor:                   PropTypes.func,
     labelExtractor:                 PropTypes.func,
     initValue:                      PropTypes.string,
@@ -56,6 +58,8 @@ const propTypes = {
 const defaultProps = {
     data:                           [],
     onChange:                       () => {},
+    onModalOpen:                    () => {},
+    onModalClose:                   () => {},
     keyExtractor:                   (item) => item.key,
     labelExtractor:                 (item) => item.label,
     initValue:                      'Select me!',
@@ -115,12 +119,14 @@ export default class ModalSelector extends React.Component {
     }
 
     close = () => {
+        this.props.onModalClose();
         this.setState({
             modalVisible: false,
         });
     }
 
     open = () => {
+        this.props.onModalOpen();
         this.setState({
             modalVisible: true,
             changedItem:  undefined,


### PR DESCRIPTION
I faced with a problem of ability to open two near located pickers if a user clicks fast on them. These events allow handling other pickers when there is an active one.