### PR TITLE
Disable accessibility for modal TouchableWithoutFeedback

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ export default class ModalSelector extends React.Component {
         const closeOverlay = this.props.backdropPressToClose;
 
         return (
-            <TouchableWithoutFeedback key={'modalSelector' + (componentIndex++)} onPress={() => {
+            <TouchableWithoutFeedback key={'modalSelector' + (componentIndex++)}  accessible={false} onPress={() => {
                 closeOverlay && this.close();
             }}>
                 <View style={[styles.overlayStyle, this.props.overlayStyle]}>


### PR DESCRIPTION
The TouchableWithoutFeeback that wraps the entire option list to enable dismissing the list via a tap hijacks accessibility for the option list making so automation and users with accessibility features enabled can’t interact with the option list.