### PR TITLE
Add get changed item function

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,7 @@ Prop                | Type     | Optional | Default      | Description
 `cancelButtonAccessibilityLabel` | string   | Yes      | undefined | Accessibility label for the cancel button
 `modalOpenerHitSlop` | object | Yes | {} | How far touch can stray away from touchable that opens modal ([RN docs](https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#hitslop))
 `customSelector`     | node   | Yes | undefined          | Render a custom node instead of the built-in select box.
+
+### Methods
+
+`getSelectedItem()`: get current selected item, updated by onChange event.

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ export default class ModalSelector extends React.Component {
         });
     }
 
-    getChangedItem() {
+    getSelectedItem() {
       return this.state.changedItem;
     }
 

--- a/index.js
+++ b/index.js
@@ -132,10 +132,10 @@ export default class ModalSelector extends React.Component {
             // RN >= 0.50 on iOS comes with the onDismiss prop for Modal which solves RN issue #10471
             this.props.onChange(item);
         }
-        this.setState({ selected: this.props.labelExtractor(item), changedItem: item });
-
-        if (this.props.closeOnChange)
-            this.close();
+        this.setState({ selected: this.props.labelExtractor(item), changedItem: item }, {
+          if (this.props.closeOnChange)
+            this.close();          
+        });
     }
 
     getChangedItem() {

--- a/index.js
+++ b/index.js
@@ -133,9 +133,13 @@ export default class ModalSelector extends React.Component {
             this.props.onChange(item);
         }
         this.setState({ selected: this.props.labelExtractor(item), changedItem: item });
-        
+
         if (this.props.closeOnChange)
             this.close();
+    }
+
+    getChangedItem() {
+      return this.state.changedItem;
     }
 
     close = () => {

--- a/index.js
+++ b/index.js
@@ -132,9 +132,9 @@ export default class ModalSelector extends React.Component {
             // RN >= 0.50 on iOS comes with the onDismiss prop for Modal which solves RN issue #10471
             this.props.onChange(item);
         }
-        this.setState({ selected: this.props.labelExtractor(item), changedItem: item }, {
+        this.setState({ selected: this.props.labelExtractor(item), changedItem: item }, () => {
           if (this.props.closeOnChange)
-            this.close();          
+            this.close();
         });
     }
 


### PR DESCRIPTION
Added `getChangedItem` method and moved `this.props.closeOnChange` to the `setState` callback so changedItem via getChangedItem is immetdiatly available `onModalClose` event.