### PR TITLE
Add custom component/selector example in README/SampleApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i react-native-modal-selector --save
 
 ## Usage
 
-You can either use this component as an wrapper around your existing component or use it in its default mode. In default mode a customizable button is rendered.
+You can either use this component in its default mode, as a wrapper around your existing component or provide a custom component (where you need to control opening of the modal yourself). In default mode a customizable button is rendered.
 
 See `SampleApp` for an example how to use this component.
 
@@ -72,6 +72,13 @@ class SampleApp extends Component {
                         value={this.state.textInputValue} />
 
                 </ModalSelector>
+
+                // Custom component
+                <ModalSelector
+                    data={data}
+                    ref={selector => { this.selector = selector; }}
+                    customSelector={<Switch onValueChange={() => this.selector.open()} />}
+                />
             </View>
         );
     }

--- a/SampleApp/App.js
+++ b/SampleApp/App.js
@@ -4,7 +4,8 @@ import React, { Component } from 'react';
 
 import {
     View,
-    TextInput
+    TextInput,
+    Switch
 } from 'react-native';
 
 import ModalSelector from 'react-native-modal-selector'
@@ -64,6 +65,21 @@ class SampleApp extends Component {
                         value={this.state.textInputValue} />
 
                 </ModalSelector>
+
+                { /*
+                    Custom mode: you have to provide a react-native component that have to
+                    control how the selector should open (and for this you need a ref to the modal)
+                 */ }
+                <ModalSelector
+                    data={data}
+                    ref={selector => { this.selector = selector; }}
+                    customSelector={
+                        <Switch
+                            style={{ alignSelf: 'center' }}
+                            onValueChange={() => this.selector.open()}
+                        />
+                    }
+                />
             </View>
         );
     }


### PR DESCRIPTION
It can be a bit difficult for newcomers to see how to use the `customSelector`, so here is an example. Also revised the README to reflect the three modes the modal selector can be used now.