### PR TITLE
Added pass through props for Text components

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Prop                | Type     | Optional | Default      | Description
 `cancelContainerStyle`| object | Yes      | {}           | style definitions for the cancel container
 `backdropPressToClose`| bool   | Yes  | false        | `true` makes the modal close when the overlay is pressed
 `passThruProps`| object   | Yes  | {}        | props to pass through to the container View and each option TouchableOpacity (e.g. testID for testing)
+`selectTextPassThruProps`| object   | Yes  | {}        | props to pass through to the select text component
+`optionTextPassThruProps`| object   | Yes  | {}        | props to pass through to the options text components in the modal
 `openButtonContainerAccessible`| bool   | Yes  | false        | `true` enables accessibility for the open button container. Note: if `false` be sure to define accessibility props directly in the wrapped component.
 `listItemAccessible`| bool   | Yes  | false        | `true` enables accessibility for data items. Note: data items should have an `accessibilityLabel` property if this is enabled
 `cancelButtonAccessible`| bool   | Yes  | false        | `true` enables accessibility for cancel button.

--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ const propTypes = {
     scrollViewAccessibilityLabel:   PropTypes.string,
     cancelButtonAccessibilityLabel: PropTypes.string,
     passThruProps:                  PropTypes.object,
+    selectTextPassThruProps:        PropTypes.object,
+    optionTextPassThruProps:        PropTypes.object,
     modalOpenerHitSlop:             PropTypes.object,
     customSelector:                 PropTypes.node,
 };
@@ -102,6 +104,8 @@ const defaultProps = {
     scrollViewAccessibilityLabel:   undefined,
     cancelButtonAccessibilityLabel: undefined,
     passThruProps:                  {},
+    selectTextPassThruProps:        {},
+    optionTextPassThruProps:        {},
     modalOpenerHitSlop:             {top: 0, bottom: 0, left: 0, right: 0},
     customSelector:                 undefined,
 };
@@ -189,8 +193,7 @@ export default class ModalSelector extends React.Component {
             >
                 <View style={[styles.optionStyle, this.props.optionStyle, isLastItem &&
                 {borderBottomWidth: 0}]}>
-                    <Text style={[styles.optionTextStyle,this.props.optionTextStyle,
-                                 isSelectedItem && this.props.selectedItemTextStyle]}>
+                    <Text style={[styles.optionTextStyle,this.props.optionTextStyle,isSelectedItem && this.props.selectedItemTextStyle]} {...this.props.optionTextPassThruProps}>
                         {optionLabel}
                     </Text>
                 </View>
@@ -238,7 +241,7 @@ export default class ModalSelector extends React.Component {
         }
         return (
             <View style={[styles.selectStyle, this.props.selectStyle]}>
-                <Text style={[styles.selectTextStyle, this.props.selectTextStyle]}>{this.state.selected}</Text>
+                <Text style={[styles.selectTextStyle, this.props.selectTextStyle]} {...this.props.selectTextPassThruProps}>{this.state.selected}</Text>
             </View>
         );
     }


### PR DESCRIPTION
Added `optionTextPassThruProps` and `selectTextPassThruProps` to allow users to pass props to Text components