### PR TITLE
Add selectedKey prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Prop                | Type     | Optional | Default      | Description
 `cancelButtonAccessibilityLabel` | string   | Yes      | undefined | Accessibility label for the cancel button
 `modalOpenerHitSlop` | object | Yes | {} | How far touch can stray away from touchable that opens modal ([RN docs](https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#hitslop))
 `customSelector`     | node   | Yes | undefined          | Render a custom node instead of the built-in select box.
-`selectedKey`     | any   | Yes | ''          | Key and label to be initially selected
+`selectedKey`     | any   | Yes | ''          | Key of the item to be initially selected
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Prop                | Type     | Optional | Default      | Description
 `cancelButtonAccessibilityLabel` | string   | Yes      | undefined | Accessibility label for the cancel button
 `modalOpenerHitSlop` | object | Yes | {} | How far touch can stray away from touchable that opens modal ([RN docs](https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#hitslop))
 `customSelector`     | node   | Yes | undefined          | Render a custom node instead of the built-in select box.
+`selectedKey`     | any   | Yes | ''          | Key and label to be initially selected
 
 ### Methods
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ const propTypes = {
     optionTextPassThruProps:        PropTypes.object,
     modalOpenerHitSlop:             PropTypes.object,
     customSelector:                 PropTypes.node,
+    selectedIndex:                  PropTypes.number,
 };
 
 const defaultProps = {
@@ -117,16 +118,17 @@ const defaultProps = {
     optionTextPassThruProps:        {},
     modalOpenerHitSlop:             {top: 0, bottom: 0, left: 0, right: 0},
     customSelector:                 undefined,
+    selectedIndex:                  -1
 };
 
 export default class ModalSelector extends React.Component {
 
     constructor(props) {
         super(props);
-
+        let selected = props.selectedIndex > -1 ? props.labelExtractor(props.data[props.selectedIndex]) : props.initValue;
         this.state = {
             modalVisible:  props.visible,
-            selected:      props.initValue,
+            selected:      selected,
             cancelText:    props.cancelText,
             changedItem:   undefined,
         };

--- a/index.js
+++ b/index.js
@@ -125,14 +125,12 @@ export default class ModalSelector extends React.Component {
 
     constructor(props) {
         super(props);
-        let selectedItem = props.data.filter((item) => props.keyExtractor(item) === props.selectedKey);
-        let selectedLabel = selectedItem.length > 0 ? props.labelExtractor(selectedItem[0]) : props.initValue;
-        let selectedKey = selectedItem.length > 0 ? props.selectedKey : undefined;
+        let selectedItem = this.validateSelectedKey(props.selectedKey);
         this.state = {
             modalVisible:  props.visible,
-            selected:      selectedLabel,
+            selected:      selectedItem.label,
             cancelText:    props.cancelText,
-            changedItem:   selectedKey,
+            changedItem:   selectedItem.key,
         };
     }
 
@@ -147,9 +145,22 @@ export default class ModalSelector extends React.Component {
             newState.modalVisible = this.props.visible;
             doUpdate = true;
         }
+        if(prevProps.selectedKey !== this.props.selectedKey){
+            let selectedItem = this.validateSelectedKey(this.props.selectedKey);
+            newState.selected = selectedItem.label;
+            newState.changedItem = selectedItem.key;
+            doUpdate = true;
+        }
         if (doUpdate) {
             this.setState(newState);
         }
+    }
+
+    validateSelectedKey = (key) => {
+        let selectedItem = this.props.data.filter((item) => this.props.keyExtractor(item) === key);
+        let selectedLabel = selectedItem.length > 0 ? this.props.labelExtractor(selectedItem[0]) : this.props.initValue;
+        let selectedKey = selectedItem.length > 0 ? key : undefined;
+        return {label: selectedLabel, key: selectedKey}
     }
 
     onChange = (item) => {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const propTypes = {
     optionTextPassThruProps:        PropTypes.object,
     modalOpenerHitSlop:             PropTypes.object,
     customSelector:                 PropTypes.node,
-    selectedIndex:                  PropTypes.number,
+    selectedKey:                    PropTypes.any,
 };
 
 const defaultProps = {
@@ -107,7 +107,7 @@ const defaultProps = {
     supportedOrientations:          ['portrait', 'landscape'],
     keyboardShouldPersistTaps:      'always',
     backdropPressToClose:           false,
-    openButtonContainerAccessible:     false,
+    openButtonContainerAccessible:  false,
     listItemAccessible:             false,
     cancelButtonAccessible:         false,
     scrollViewAccessible:           false,
@@ -118,14 +118,16 @@ const defaultProps = {
     optionTextPassThruProps:        {},
     modalOpenerHitSlop:             {top: 0, bottom: 0, left: 0, right: 0},
     customSelector:                 undefined,
-    selectedIndex:                  -1
+    selectedKey:                    ''
 };
 
 export default class ModalSelector extends React.Component {
 
     constructor(props) {
         super(props);
-        let selected = props.selectedIndex > -1 ? props.labelExtractor(props.data[props.selectedIndex]) : props.initValue;
+        let selected = props.initValue;
+        let selectedKey = props.data.filter((item) => props.keyExtractor(item) === props.selectedKey);
+        if(selectedKey.length > 0) selected = props.labelExtractor(selectedKey[0]);
         this.state = {
             modalVisible:  props.visible,
             selected:      selected,

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const propTypes = {
     optionTextPassThruProps:        PropTypes.object,
     modalOpenerHitSlop:             PropTypes.object,
     customSelector:                 PropTypes.node,
-    selectedLabel:                  PropTypes.string,
+    selectedKey:                    PropTypes.any,
 };
 
 const defaultProps = {
@@ -118,20 +118,21 @@ const defaultProps = {
     optionTextPassThruProps:        {},
     modalOpenerHitSlop:             {top: 0, bottom: 0, left: 0, right: 0},
     customSelector:                 undefined,
-    selectedLabel:                  ''
+    selectedKey:                    '',
 };
 
 export default class ModalSelector extends React.Component {
 
     constructor(props) {
         super(props);
-        let selectedItem = props.data.filter(item => props.labelExtractor(item) === props.selectedLabel);
-        let selected = selectedItem.length > 0 ? props.selectedLabel : props.initValue;
+        let selectedItem = props.data.filter((item) => props.keyExtractor(item) === props.selectedKey);
+        let selectedLabel = selectedItem.length > 0 ? props.labelExtractor(selectedItem[0]) : props.initValue;
+        let selectedKey = selectedItem.length > 0 ? props.selectedKey : undefined;
         this.state = {
             modalVisible:  props.visible,
-            selected:      selected,
+            selected:      selectedLabel,
             cancelText:    props.cancelText,
-            changedItem:   undefined,
+            changedItem:   selectedKey,
         };
     }
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const propTypes = {
     optionTextPassThruProps:        PropTypes.object,
     modalOpenerHitSlop:             PropTypes.object,
     customSelector:                 PropTypes.node,
-    selectedKey:                    PropTypes.any,
+    selectedLabel:                  PropTypes.string,
 };
 
 const defaultProps = {
@@ -118,16 +118,15 @@ const defaultProps = {
     optionTextPassThruProps:        {},
     modalOpenerHitSlop:             {top: 0, bottom: 0, left: 0, right: 0},
     customSelector:                 undefined,
-    selectedKey:                    ''
+    selectedLabel:                  ''
 };
 
 export default class ModalSelector extends React.Component {
 
     constructor(props) {
         super(props);
-        let selected = props.initValue;
-        let selectedKey = props.data.filter((item) => props.keyExtractor(item) === props.selectedKey);
-        if(selectedKey.length > 0) selected = props.labelExtractor(selectedKey[0]);
+        let selectedItem = props.data.filter(item => props.labelExtractor(item) === props.selectedLabel);
+        let selected = selectedItem.length > 0 ? props.selectedLabel : props.initValue;
         this.state = {
             modalVisible:  props.visible,
             selected:      selected,


### PR DESCRIPTION
The value provided must be a key present in one item of the array items provided as data.
If the key provided is not present in the array, displayed value will be `initValue`.

E.g: If I have this array as data
```
let data = [
  {label: 'First option', key: 0},
  {label: 'Second option', key: 1},
  {label: 'Third option', key: 2},
]
```
and I want the second one to be displayed (`Second option`), I have to pass `1` on `selectedKey`:
```
<ModalSelector
  data={data}
  selectedKey={1}
/>
```
closes: https://github.com/peacechen/react-native-modal-selector/issues/52, https://github.com/peacechen/react-native-modal-selector/issues/63, https://github.com/peacechen/react-native-modal-selector/issues/80