### PR TITLE
onModalClose returns selected item

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Prop                | Type     | Optional | Default      | Description
 `data`              | array    | No       | []           | array of objects with a unique `key` and `label` to select in the modal. Optional `component` overrides label text.
 `onChange`          | function | Yes      | () => {}     | callback function, when the users has selected an option
 `onModalOpen`       | function | Yes      | () => {}     | callback function, when modal is opening
-`onModalClose`      | function | Yes      | () => {}     | callback function, when modal is closing
+`onModalClose`      | function | Yes      | (item) => {} | callback function, when modal is closing. Returns the selected item.
 `keyExtractor`      | function | Yes      | (data) => data.key   | extract the key from the data item
 `labelExtractor`    | function | Yes      | (data) => data.label | extract the label from the data item
 `componentExtractor`| function | Yes      | (data) => data.component | extract the component from the data item

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ export default class ModalSelector extends React.Component {
         }
         this.setState({ selected: this.props.labelExtractor(item), changedItem: item }, () => {
           if (this.props.closeOnChange)
-            this.close();
+            this.close(item);
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -180,8 +180,8 @@ export default class ModalSelector extends React.Component {
       return this.state.changedItem;
     }
 
-    close = () => {
-        this.props.onModalClose();
+    close = (item) => {
+        this.props.onModalClose(item);
         this.setState({
             modalVisible: false,
         });


### PR DESCRIPTION
Under IOS onChange doesn't seem to fire.  Passing selected item when the modal closes is a reasonable workaround.  Also makes the code simpler as can simply deal with modal close.