### PR TITLE
Fix selectTextStyle should have correct TextStyle type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -117,7 +117,7 @@ interface IModalSelectorProps<TOption> {
    * 
    * Default is `{}`
    */
-  selectTextStyle?: ViewStyle;
+  selectTextStyle?: TextStyle;
 
   /**
    * Style definitions for the option element


### PR DESCRIPTION
The `selectTextStyle` is correctly types in the react props, but not in the Typescript type. It should be a textStyle.