### PR TITLE
Update selected item state when data prop updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ export default class ModalSelector extends React.Component {
             newState.modalVisible = this.props.visible;
             doUpdate = true;
         }
-        if(prevProps.selectedKey !== this.props.selectedKey){
+        if (prevProps.selectedKey !== this.props.selectedKey || prevProps.data !== this.props.data) {
             let selectedItem = this.validateSelectedKey(this.props.selectedKey);
             newState.selected = selectedItem.label;
             newState.changedItem = selectedItem.key;


### PR DESCRIPTION
This fixes a bug where the option is not selected when `selectedKey` is set before the corresponding `data`.