### PR TITLE
Add option param to onModalClose type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ interface IModalSelectorProps<TOption> {
    *
    * Default is `() => {}`
    */
-  onModalClose?: () => void;
+  onModalClose?: (option: TOption) => void;
 
   /**
    * Extract the key from the data item


### PR DESCRIPTION
Fix TypeScript typing for onModalClose to reflect the selected item being returned in the call